### PR TITLE
ci: remove the filter excluding quality.cpp from the tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   
   build-gcc10:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   
   build-gcc10-cpp20:
     runs-on: ubuntu-latest
@@ -77,7 +77,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   
   build-gcc12:
     runs-on: ubuntu-latest
@@ -100,7 +100,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   
   build-clang11:
     runs-on: ubuntu-22.04
@@ -123,7 +123,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   
   build-clang13:
     runs-on: ubuntu-22.04
@@ -146,7 +146,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   
   build-clang13-asan:
     runs-on: ubuntu-22.04
@@ -169,7 +169,7 @@ jobs:
     - name: Run tests with ASAN
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   
   compile-gcc9:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   build-clang14:
     name: Clang 14
     runs-on: macOS-latest
@@ -44,7 +44,7 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests
   build-clang15:
     name: Clang 15
     runs-on: macOS-latest
@@ -62,4 +62,4 @@ jobs:
     - name: Run tests
       run: |
         cd build
-        ./test/run_tests "~[quality]"
+        ./test/run_tests

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,4 +37,4 @@ jobs:
       - name: Run tests
         run: |
           cd build
-          .\test\Debug\run_tests "~[quality]"
+          .\test\Debug\run_tests


### PR DESCRIPTION
The `quality.cpp` file was previously excluded from the test workflow, which prevented the CI from detecting issues introduced in earlier PRs. This PR ensures that `quality.cpp` is properly included, allowing the workflow to catch potential errors that would otherwise only be noticed locally.